### PR TITLE
Add aarch64 wheel build support 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -624,9 +624,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-built"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b01f9a39798d591d2ae7552886de8e0205a74782ab6b26f9224f190b3766d9cb"
+checksum = "843c5bf7972395017ef1e6ba68a69668a1e52da2bc1ab81545a20894b7a866cd"
 
 [[package]]
 name = "pyo3-macros"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ built = { version  = "0.4.1", features = ["chrono"] }
 
 [dependencies]
 libc = "0.2.70"
-pyo3-built = "0.4.5"
+pyo3-built = "0.4.6"
 pest = "=2.1.3"
 [dependencies.pyo3]
 version = "0.14.1"


### PR DESCRIPTION
**Package Owner:** Hirni Meshram

**PR change Details:** Added Linux aarch64 wheel support.

**Testing Detail:** 

- Wheel Build: https://github.com/hirnimeshrampuresoftware/fastobo-py/actions/runs/1138245927
- Tests: https://github.com/hirnimeshrampuresoftware/fastobo-py/actions/runs/1135468623

**Peer Reviewer:** Disha Srivastava

**Reviewer:** Pruthvi Teja Reddy